### PR TITLE
Fix server port and remove parseRoute export

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ Try the application live at [https://another-jobify-app.herokuapp.com/]
 
 9. Start development environment
 
-  ```shell
+ ```shell
   npm run dev
+  ```
+
+10. Build the client for production
+
+  ```shell
+  npm run build
   ```

--- a/client/lib/index.js
+++ b/client/lib/index.js
@@ -1,1 +1,0 @@
-export { default as parseRoute } from './parse-route';

--- a/server/index.js
+++ b/server/index.js
@@ -415,6 +415,7 @@ app.delete('/api/auth/delete-card/:deleteJobId',
 
 app.use(errorMiddleware);
 
-app.listen(process.env.PORT, () => {
-  logger.info(`app listening on port ${process.env.PORT}`);
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  logger.info(`app listening on port ${port}`);
 });


### PR DESCRIPTION
## Summary
- default Express server to port 3000 when `PORT` not provided
- drop unused `parseRoute` export and document the client build step

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688c5b5e780083258317046ef5c4d339