### PR TITLE
feat: add Google OAuth login option

### DIFF
--- a/client/components/login.jsx
+++ b/client/components/login.jsx
@@ -15,6 +15,7 @@ export default class LoginPage extends React.Component {
     this.handleEmailChange = this.handleEmailChange.bind(this);
     this.handlePasswordChange = this.handlePasswordChange.bind(this);
     this.handleDemoClick = this.handleDemoClick.bind(this);
+    this.handleGoogleClick = this.handleGoogleClick.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
@@ -34,6 +35,34 @@ export default class LoginPage extends React.Component {
       email: 'demo@gmail.com',
       password: '12345678'
     });
+  }
+
+  handleGoogleClick() {
+    this.setState({ load: true });
+    const googleWindow = window.open('/api/auth/google', 'google', 'width=500,height=600');
+    const timer = setInterval(() => {
+      if (!googleWindow || googleWindow.closed) {
+        clearInterval(timer);
+        this.setState({ load: false });
+        return;
+      }
+      try {
+        const { body } = googleWindow.document;
+        const text = body && body.innerText;
+        if (text) {
+          const data = JSON.parse(text);
+          if (data.token && data.user) {
+            const { handleSignIn } = this.context;
+            handleSignIn(data);
+            this.setState({ loginError: false, load: false });
+            googleWindow.close();
+            clearInterval(timer);
+          }
+        }
+      } catch (err) {
+        // ignore cross-origin errors until redirect returns to our domain
+      }
+    }, 500);
   }
 
   handleSubmit(event) {
@@ -104,6 +133,7 @@ export default class LoginPage extends React.Component {
           <Button className="signin-button" variant="primary" type="submit">
             Sign in
           </Button>
+          <Button className='google-b' onClick={this.handleGoogleClick}>Sign in with Google</Button>
           <p className="red-warning-two">{errorMsg}</p>
           <OverlayTrigger
             placement="top"


### PR DESCRIPTION
## Summary
- add Google sign-in button to login page
- handle popup OAuth flow and sign user in when it completes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint client/components/login.jsx`

------
https://chatgpt.com/codex/tasks/task_e_688d1d20eaac8325bcd10facfe9f1a43